### PR TITLE
Remove extra whitespace that affects the sitemap indentation

### DIFF
--- a/templates/sitemap.xml.erb
+++ b/templates/sitemap.xml.erb
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <% @pages.each do |p| %>
-    <% unless p.data.noindex %>
+<% unless p.data.noindex %>
   <url>
     <loc><%= @hostname + encode(p.url) %></loc>
 <% if p.data.lastmod %>    <lastmod><%= p.data.lastmod %></lastmod>


### PR DESCRIPTION
Thank you for the `noindex` feature in bd259a9da0df to exclude a page from the sitemap! It was just what I needed.

This change removes whitespace that causes the only unexpected diff between the old sitemap and the new, and makes the indentation right again.